### PR TITLE
Fix version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/00WildBlueCore/WildBlueCore.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/00WildBlueCore/WildBlueCore.version
@@ -1,6 +1,6 @@
 {
     "NAME":"WildBlueCore",
-    "URL":"https://raw.githubusercontent.com/Angel-125/WildBlueCore/master/GameData/WildBlueIndustries/WildBlueCore/WildBlueCore.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/WildBlueCore/main/ReleaseFolder/GameData/WildBlueIndustries/00WildBlueCore/WildBlueCore.version",
     "DOWNLOAD":"https://github.com/Angel-125/WildBlueCore/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125!

The URL property of the version file is a 404 currently.

- This repo apparently uses a `main` branch instead of `master`
- `ReleaseFolder` missing from path
- `00` missing from `WildBlueCore` path component

This pull request fixes it.

Noticed while reviewing KSP-CKAN/NetKAN#9310.